### PR TITLE
replace class_name_dict with results.names

### DIFF
--- a/local_env/predict_video.py
+++ b/local_env/predict_video.py
@@ -21,8 +21,6 @@ model = YOLO(model_path)  # load a custom model
 
 threshold = 0.5
 
-class_name_dict = {0: 'alpaca'}
-
 while ret:
 
     results = model(frame)[0]
@@ -32,7 +30,7 @@ while ret:
 
         if score > threshold:
             cv2.rectangle(frame, (int(x1), int(y1)), (int(x2), int(y2)), (0, 255, 0), 4)
-            cv2.putText(frame, class_name_dict[int(class_id)].upper(), (int(x1), int(y1 - 10)),
+            cv2.putText(frame, results.names[int(class_id)].upper(), (int(x1), int(y1 - 10)),
                         cv2.FONT_HERSHEY_SIMPLEX, 1.3, (0, 255, 0), 3, cv2.LINE_AA)
 
     out.write(frame)


### PR DESCRIPTION
This pull request simplifies the code by replacing the usage of class_name_dict with results.names. results.names is a dictionary that already contains the classes the model is trained on, eliminating the need to create a separate dictionary for the classes. 